### PR TITLE
HB2-87 add update button to refresh route from remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change Log
+## [0.14.0] - 2020-11-12 update routes from remote
+- Update route button from the route page
+- Redirect to route update after Switzerland Mobility login
+- Manage permissions for route update
+- Remove Garmin upload interface for now
+
 ## [0.13.0] - 2020-11-08 import places from geonames.org
 - Places can be imported from geonames.org for any country
 - Import SwissNAMES3D from CSV file instead of shapefile

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.gis",
     "django.contrib.humanize",
     "social_django",
+    "rules",
     "widget_tweaks",
     "djgeojson",
     "leaflet",
@@ -220,6 +221,7 @@ SOCIAL_AUTH_URL_NAMESPACE = "social"
 
 AUTHENTICATION_BACKENDS = (
     "social_core.backends.strava.StravaOAuth",
+    "rules.permissions.ObjectPermissionBackend",
     "django.contrib.auth.backends.ModelBackend",
 )
 

--- a/homebytwo/importers/decorators.py
+++ b/homebytwo/importers/decorators.py
@@ -49,7 +49,7 @@ def remote_connection(view_func):
     @wraps(view_func)
     def _wrapped_view(request, *args, **kwargs):
         try:
-            response = view_func(request, *args, **kwargs)
+            return view_func(request, *args, **kwargs)
 
         except ConnectionError as error:
             message = (
@@ -78,17 +78,20 @@ def remote_connection(view_func):
             # redirect to Switzerland Mobility log-in page
             login_url = reverse("switzerland_mobility_login")
 
-            # add route_id as a GET param if trying to import a route
+            # add GET param if the athlete wanted to to import or update a route
             match = request.resolver_match
-            if match.url_name == "import_route":
-                route_id = match.kwargs["source_id"]
-                params = urlencode({"route_id": route_id})
-                return redirect(f"{login_url}?{params}")
-            else:
-                return redirect(login_url)
 
-        # no exception, return the response from the decorated view
-        else:
-            return response
+            # the athlete wanted to import a route
+            if match.url_name == "import_route":
+                params = urlencode({"import": match.kwargs["source_id"]})
+                return redirect(f"{login_url}?{params}")
+
+            # the athlete wanted to update a route
+            if match.url_name == "update":
+                params = urlencode({"update": match.kwargs["pk"]})
+                return redirect(f"{login_url}?{params}")
+
+            # the athlete wanted something else
+            return redirect(login_url)
 
     return _wrapped_view

--- a/homebytwo/importers/decorators.py
+++ b/homebytwo/importers/decorators.py
@@ -87,7 +87,7 @@ def remote_connection(view_func):
                 return redirect(f"{login_url}?{params}")
 
             # the athlete wanted to update a route
-            if match.url_name == "update":
+            if match.app_name == "routes" and match.url_name == "update":
                 params = urlencode({"update": match.kwargs["pk"]})
                 return redirect(f"{login_url}?{params}")
 

--- a/homebytwo/importers/tests/test_gpx_import.py
+++ b/homebytwo/importers/tests/test_gpx_import.py
@@ -3,9 +3,15 @@ from django.urls import reverse
 
 from pandas import DataFrame
 from pytest import approx
-from pytest_django.asserts import assertRedirects, assertTemplateUsed
+from pytest_django.asserts import (
+    assertContains,
+    assertNotContains,
+    assertRedirects,
+    assertTemplateUsed,
+)
 
 from ...routes.models import Route
+from ...routes.tests.factories import RouteFactory
 from ..forms import GpxUploadForm
 
 
@@ -69,3 +75,16 @@ def test_upload_gpx_view_empty(athlete, client, uploaded_file):
     url = reverse("upload_gpx")
     response = client.post(url, data={"gpx": gpx_file})
     assertTemplateUsed(response, "importers/index.html")
+
+
+def test_get_gpx_route_no_update_button(athlete, client):
+    route = RouteFactory(data_source="homebytwo", athlete=athlete)
+    response = client.get(route.get_absolute_url())
+    assertContains(response, route.edit_url)
+    assertNotContains(response, route.get_absolute_url("update"))
+
+
+def test_get_update_gpx_route(athlete, client):
+    route = RouteFactory(data_source="homebytwo", athlete=athlete)
+    response = client.get(route.update_url)
+    assert response.status_code == 404

--- a/homebytwo/importers/tests/test_switzerlandmobilityroute.py
+++ b/homebytwo/importers/tests/test_switzerlandmobilityroute.py
@@ -1,8 +1,10 @@
+from functools import partial
 from json import loads as json_loads
 from os.path import dirname, realpath
 from pathlib import Path
 from re import compile as re_compile
 
+import pytest
 from django.conf import settings
 from django.contrib.gis.geos import LineString, Point
 from django.forms.models import model_to_dict
@@ -509,22 +511,6 @@ class SwitzerlandMobilityTestCase(TestCase):
         title = "<title>Home by Two - Import Haute Cime</title>"
         self.assertContains(response, title, html=True)
 
-    def test_switzerland_mobility_route_redirect_to_login_with_route_id(self):
-        session = self.client.session
-        del session["switzerland_mobility_cookies"]
-        session.save()
-
-        source_id = 123456789
-        response = self.get_import_route_response(
-            route_id=source_id,
-            response_file="403.json",
-            status=403,
-        )
-
-        params = urlencode({"route_id": source_id})
-        assert response.status_code == 302
-        assert params in response.url
-
     def test_switzerland_mobility_route_already_imported(self):
         route_id = 2733343
         SwitzerlandMobilityRouteFactory(
@@ -657,142 +643,6 @@ class SwitzerlandMobilityTestCase(TestCase):
 
         self.assertEqual(response.url, redirect_url)
 
-    def test_switzerland_mobility_get_login_view(self):
-        url = reverse("switzerland_mobility_login")
-        content = '<form method="post">'
-        response = self.client.get(url)
-
-        self.assertContains(response, content)
-
-    @responses.activate
-    def test_switzerland_mobility_login_successful(self):
-        json_response = '{"loginErrorMsg": "", "loginErrorCode": 200}'
-        adding_headers = {"Set-Cookie": "mf-chmobil=123"}
-
-        responses.add(
-            responses.POST,
-            settings.SWITZERLAND_MOBILITY_LOGIN_URL,
-            content_type="application/json",
-            body=json_response,
-            status=200,
-            adding_headers=adding_headers,
-        )
-
-        url = reverse("switzerland_mobility_login")
-        data = {"username": "test_user", "password": "test_password"}
-        response = self.client.post(url, data)
-
-        mobility_cookies = self.client.session["switzerland_mobility_cookies"]
-        redirect_url = resolve_url("import_routes", data_source="switzerland_mobility")
-
-        assert response.status_code == 302
-        assert response.url == redirect_url
-        assert mobility_cookies["mf-chmobil"] == "123"
-
-    @responses.activate
-    def test_switzerland_mobility_login_successful_route_id(self):
-        json_response = '{"loginErrorMsg": "", "loginErrorCode": 200}'
-        adding_headers = {"Set-Cookie": "mf-chmobil=123"}
-
-        responses.add(
-            responses.POST,
-            settings.SWITZERLAND_MOBILITY_LOGIN_URL,
-            content_type="application/json",
-            body=json_response,
-            status=200,
-            adding_headers=adding_headers,
-        )
-        source_id = 123456789
-        url = reverse("switzerland_mobility_login")
-        params = urlencode({"route_id": source_id})
-        data = {"username": "test_user", "password": "test_password"}
-        response = self.client.post(f"{url}?{params}", data)
-
-        mobility_cookies = self.client.session["switzerland_mobility_cookies"]
-        redirect_url = resolve_url(
-            "import_route", data_source="switzerland_mobility", source_id=source_id
-        )
-
-        assert response.status_code == 302
-        assert response.url == redirect_url
-        assert mobility_cookies["mf-chmobil"] == "123"
-
-    @responses.activate
-    def test_switzerland_mobility_login_successful_route_id_bad(self):
-        json_response = '{"loginErrorMsg": "", "loginErrorCode": 200}'
-        adding_headers = {"Set-Cookie": "mf-chmobil=123"}
-
-        responses.add(
-            responses.POST,
-            settings.SWITZERLAND_MOBILITY_LOGIN_URL,
-            content_type="application/json",
-            body=json_response,
-            status=200,
-            adding_headers=adding_headers,
-        )
-
-        url = reverse("switzerland_mobility_login")
-        params = urlencode({"route_id": "bad_id"})
-        data = {"username": "test_user", "password": "test_password"}
-        response = self.client.post(f"{url}?{params}", data)
-
-        mobility_cookies = self.client.session["switzerland_mobility_cookies"]
-        redirect_url = resolve_url("import_routes", data_source="switzerland_mobility")
-
-        assert response.status_code == 302
-        assert response.url == redirect_url
-        assert mobility_cookies["mf-chmobil"] == "123"
-
-    @responses.activate
-    def test_switzerland_mobility_login_failed(self):
-        # remove switzerland mobility cookies
-        session = self.client.session
-        del session["switzerland_mobility_cookies"]
-        session.save()
-
-        url = reverse("switzerland_mobility_login")
-        data = {"username": "test_user", "password": "test_password"}
-
-        # intercept call to map.wanderland.ch with responses
-        login_url = settings.SWITZERLAND_MOBILITY_LOGIN_URL
-        # failed login response
-        json_response = (
-            '{"loginErrorMsg": "Incorrect login.", ' '"loginErrorCode": 500}'
-        )
-
-        responses.add(
-            responses.POST,
-            login_url,
-            content_type="application/json",
-            body=json_response,
-            status=200,
-        )
-        response = self.client.post(url, data)
-
-        self.assertContains(response, "Incorrect login.")
-        assert "switzerland_mobility_cookies" not in self.client.session
-
-    @responses.activate
-    def test_switzerland_mobility_login_server_error(self):
-        url = reverse("switzerland_mobility_login")
-        data = {"username": "test_user", "password": "test_password"}
-        content = "Error 500: logging to Switzerland Mobility."
-
-        # intercept call to map.wanderland.ch with responses
-        login_url = settings.SWITZERLAND_MOBILITY_LOGIN_URL
-        responses.add(responses.POST, login_url, status=500)
-
-        response = self.client.post(url, data)
-
-        self.assertContains(response, content)
-
-    def test_switzerland_mobility_login_method_not_allowed(self):
-        url = reverse("switzerland_mobility_login")
-        data = {"username": "test_user", "password": "test_password"}
-        response = self.client.put(url, data)
-
-        self.assertEqual(response.status_code, 405)
-
     #########
     # Forms #
     #########
@@ -837,22 +687,190 @@ class SwitzerlandMobilityTestCase(TestCase):
         self.assertFalse(form.is_valid())
 
 
-def test_switzerland_mobility_route_post_success_no_checkpoints(
-    athlete, client, mock_import_route_call_response
-):
-    source_id = 2191833
-    route = SwitzerlandMobilityRouteFactory.build(source_id=source_id)
+@pytest.fixture
+def mock_login_response(mocked_responses, settings):
+    settings.SWITZERLAND_MOBILITY_LOGIN_URL = "https://example.com/login"
+    json_response = '{"loginErrorMsg": "", "loginErrorCode": 200}'
+    adding_headers = {"Set-Cookie": "mf-chmobil=123"}
 
-    post_data = get_route_post_data(route)
-    response = mock_import_route_call_response(
-        route.data_source,
-        route.source_id,
-        method="post",
-        post_data=post_data,
+    def _mock_login_response():
+        mocked_responses.add(
+            responses.POST,
+            settings.SWITZERLAND_MOBILITY_LOGIN_URL,
+            body=json_response,
+            adding_headers=adding_headers,
+            content_type="application/json",
+            status=200,
+        )
+
+    return _mock_login_response
+
+
+@pytest.fixture
+def mock_failed_login_response(mocked_responses, settings):
+    settings.SWITZERLAND_MOBILITY_LOGIN_URL = "https://example.com/login"
+    json_response = '{"loginErrorMsg": "Incorrect login.", ' '"loginErrorCode": 500}'
+
+    def _mock_failed_login_response():
+        mocked_responses.add(
+            responses.POST,
+            settings.SWITZERLAND_MOBILITY_LOGIN_URL,
+            content_type="application/json",
+            body=json_response,
+            status=200,
+        )
+
+    return _mock_failed_login_response
+
+
+@pytest.fixture
+def mock_sm_routes_response(mock_routes_response, settings):
+    settings.SWITZERLAND_MOBILITY_LIST_URL = (
+        settings.SWITZERLAND_MOBILITY_LIST_URL or "https://example.com/tracks"
+    )
+    return partial(mock_routes_response, data_source="switzerland_mobility")
+
+
+@pytest.fixture
+def mock_sm_route_response(mock_route_details_response):
+    return partial(mock_route_details_response, "switzerland_mobility")
+
+
+###################################
+# view switzerland_mobility_login #
+###################################
+
+
+def test_get_switzerland_mobility_login(athlete, client):
+    url = reverse("switzerland_mobility_login")
+    form_content = '<form method="post">'
+    text_content = "We do not store your Switzerland Mobility log-in details."
+    response = client.get(url)
+
+    assertContains(response, form_content)
+    assertContains(response, text_content)
+
+
+def test_post_switzerland_mobility_login(
+    athlete, client, mock_login_response, mock_sm_routes_response
+):
+
+    url = reverse("switzerland_mobility_login")
+    data = {"username": "test_user", "password": "test_password"}
+    mock_login_response()
+    mock_sm_routes_response(athlete=athlete)
+    response = client.post(url, data)
+
+    mobility_cookies = client.session["switzerland_mobility_cookies"]
+    redirect_url = resolve_url("import_routes", data_source="switzerland_mobility")
+
+    assertRedirects(response, redirect_url)
+    assert mobility_cookies["mf-chmobil"] == "123"
+
+
+def test_post_switzerland_mobility_login_import_id(
+    athlete, client, mock_login_response, mock_sm_route_response
+):
+    source_id = 1234567
+    url = reverse("switzerland_mobility_login")
+    params = urlencode({"import": source_id})
+    data = {"username": athlete.user.username, "password": "test_password"}
+    mock_login_response()
+    mock_sm_route_response(source_id=source_id)
+    response = client.post(f"{url}?{params}", data)
+
+    mobility_cookies = client.session["switzerland_mobility_cookies"]
+    redirect_url = resolve_url(
+        "import_route", data_source="switzerland_mobility", source_id=source_id
     )
 
-    route = SwitzerlandMobilityRoute.objects.get(source_id=source_id)
-    assertRedirects(response, route.get_absolute_url())
+    assertRedirects(response, redirect_url)
+    assert mobility_cookies["mf-chmobil"] == "123"
+
+
+def test_post_switzerland_mobility_login_import_id_bad(
+    athlete, client, mock_login_response, mock_sm_routes_response
+):
+    url = reverse("switzerland_mobility_login")
+    params = urlencode({"import": "bad_id"})
+    data = {"username": "test_user", "password": "test_password"}
+    mock_login_response()
+    mock_sm_routes_response(athlete=athlete)
+    response = client.post(f"{url}?{params}", data)
+
+    mobility_cookies = client.session["switzerland_mobility_cookies"]
+    redirect_url = resolve_url("import_routes", data_source="switzerland_mobility")
+
+    assertRedirects(response, redirect_url)
+    assert mobility_cookies["mf-chmobil"] == "123"
+
+
+def test_post_switzerland_mobility_login_update_id(
+    athlete, client, mock_login_response, mock_sm_route_response
+):
+    route = SwitzerlandMobilityRouteFactory(athlete=athlete)
+    url = reverse("switzerland_mobility_login")
+    params = urlencode({"update": route.id})
+    data = {"username": athlete.user.username, "password": "test_password"}
+    mock_login_response()
+    mock_sm_route_response(source_id=route.source_id)
+    response = client.post(f"{url}?{params}", data)
+
+    mobility_cookies = client.session["switzerland_mobility_cookies"]
+    redirect_url = route.get_absolute_url("update")
+
+    assertRedirects(response, redirect_url)
+    assert mobility_cookies["mf-chmobil"] == "123"
+
+
+def test_post_switzerland_mobility_login_update_id_bad(
+    athlete, client, mock_login_response, mock_sm_routes_response
+):
+    url = reverse("switzerland_mobility_login")
+    params = urlencode({"update": "bad_id"})
+    data = {"username": athlete.user.username, "password": "test_password"}
+    mock_login_response()
+    mock_sm_routes_response(athlete=athlete)
+    response = client.post(f"{url}?{params}", data)
+
+    mobility_cookies = client.session["switzerland_mobility_cookies"]
+    redirect_url = resolve_url("import_routes", data_source="switzerland_mobility")
+
+    assertRedirects(response, redirect_url)
+    assert mobility_cookies["mf-chmobil"] == "123"
+
+
+def test_post_switzerland_mobility_login_failed(
+    athlete, client, mock_failed_login_response
+):
+    url = reverse("switzerland_mobility_login")
+    data = {"username": "test_user", "password": "test_password"}
+    mock_failed_login_response()
+    response = client.post(url, data)
+
+    assertContains(response, "Incorrect login.")
+    assert "switzerland_mobility_cookies" not in client.session
+
+
+def test_post_switzerland_mobility_login_server_error(
+    athlete, client, mocked_responses, settings
+):
+    settings.SWITZERLAND_MOBILITY_LOGIN_URL = "https://example.com/login"
+    url = reverse("switzerland_mobility_login")
+    data = {"username": "test_user", "password": "test_password"}
+
+    mocked_responses.add(
+        responses.POST, settings.SWITZERLAND_MOBILITY_LOGIN_URL, status=500
+    )
+    response = client.post(url, data)
+
+    content = "Error while logging-in to Switzerland Mobility."
+    assertContains(response, content)
+
+
+#####################
+# view import_route #
+#####################
 
 
 def test_get_import_switzerland_mobility_route_with_checkpoints(
@@ -878,7 +896,41 @@ def test_get_import_switzerland_mobility_route_with_checkpoints(
     assert len(checkpoint_choices) == number_of_checkpoints
 
 
-def test_post_switzerland_mobility_route_with_checkpoints(
+def test_get_import_switzerland_mobility_route_redirect_to_login_with_import_id(
+    athlete, client, mock_import_route_call_response
+):
+    source_id = 123456789
+    response = mock_import_route_call_response(
+        data_source="switzerland_mobility",
+        source_id=source_id,
+        api_response_json="403.json",
+        api_response_status=403,
+    )
+
+    params = urlencode({"import": source_id})
+    redirect_url = reverse("switzerland_mobility_login") + "?" + params
+    assertRedirects(response, redirect_url)
+
+
+def test_post_import_switzerland_mobility_route_no_checkpoints(
+    athlete, client, mock_import_route_call_response
+):
+    source_id = 2191833
+    route = SwitzerlandMobilityRouteFactory.build(source_id=source_id)
+
+    post_data = get_route_post_data(route)
+    response = mock_import_route_call_response(
+        route.data_source,
+        route.source_id,
+        method="post",
+        post_data=post_data,
+    )
+
+    route = SwitzerlandMobilityRoute.objects.get(source_id=source_id)
+    assertRedirects(response, route.get_absolute_url())
+
+
+def test_post_import_switzerland_mobility_route_with_checkpoints(
     athlete,
     client,
     switzerland_mobility_data_from_json,
@@ -910,7 +962,7 @@ def test_post_switzerland_mobility_route_with_checkpoints(
     assertRedirects(post_response, new_route.get_absolute_url())
 
 
-def test_switzerland_mobility_route_post_updated(
+def test_post_import_switzerland_mobility_route_updated(
     athlete, mock_import_route_call_response
 ):
     route = SwitzerlandMobilityRouteFactory(
@@ -933,8 +985,13 @@ def test_switzerland_mobility_route_post_updated(
     assertContains(response, success_box, html=True)
 
 
-def test_switzerland_mobility_display_route_deleted_data(
-    athlete, client, mock_route_details_response
+#####################
+# view routes:route #
+#####################
+
+
+def test_get_switzerland_mobility_route_deleted_data(
+    athlete, client, mock_sm_route_response
 ):
     route_id = 2191833
     route = SwitzerlandMobilityRouteFactory(source_id=route_id, athlete=athlete)
@@ -945,7 +1002,29 @@ def test_switzerland_mobility_display_route_deleted_data(
     Path(file_path).unlink()
 
     # mock route details response
-    mock_route_details_response(route.data_source, route.source_id)
+    mock_sm_route_response(route.source_id)
     response = client.get(route.get_absolute_url())
 
     assert response.status_code == 200
+
+
+#####################
+# view routes:update #
+#####################
+
+
+def test_get_update_switzerland_mobility_route_redirect_to_login_with_update_id(
+    athlete, client, mock_sm_route_response
+):
+    route = SwitzerlandMobilityRouteFactory(athlete=athlete)
+    url = route.get_absolute_url("update")
+    mock_sm_route_response(
+        source_id=route.source_id,
+        api_response_json="403.json",
+        api_response_status=403,
+    )
+    response = client.get(url)
+
+    params = urlencode({"update": route.pk})
+    redirect_url = reverse("switzerland_mobility_login") + "?" + params
+    assertRedirects(response, redirect_url)

--- a/homebytwo/importers/views.py
+++ b/homebytwo/importers/views.py
@@ -5,6 +5,8 @@ from django.shortcuts import redirect, render
 from django.urls import NoReverseMatch
 from django.views.decorators.http import require_POST
 
+from rules.contrib.views import permission_required
+
 from ..routes.forms import RouteForm
 from .decorators import remote_connection
 from .forms import GpxUploadForm, SwitzerlandMobilityLogin
@@ -55,13 +57,13 @@ def import_routes(request, data_source):
 
 @login_required
 @remote_connection
+@permission_required("routes.import_route")
 def import_route(request, data_source, source_id):
     """
     import routes from external sources
 
     There is a modelform for the route with custom __init__ and save methods
-    to find available checkpoints and save the ones selected by the athlete
-    to the route.
+    to find available checkpoints and save the ones selected by the athlete.
     """
 
     template = "routes/route/route_form.html"

--- a/homebytwo/importers/views.py
+++ b/homebytwo/importers/views.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import NoReverseMatch
 from django.views.decorators.http import require_POST
@@ -127,49 +126,43 @@ def upload_gpx(request):
 @login_required
 @remote_connection
 def switzerland_mobility_login(request):
+    form = SwitzerlandMobilityLogin()
 
-    template = "importers/switzerland_mobility/login.html"
-
-    # POST request, validate and login
     if request.method == "POST":
 
         # instantiate login form and populate it with POST data:
         form = SwitzerlandMobilityLogin(request.POST)
 
-        # If the form validates,
-        # try to retrieve the Switzerland Mobility cookies
-        if form.is_valid():
-            cookies = form.retrieve_authorization_cookie(request)
+        # successfully logged-in to Switzerland Mobility
+        if form.is_valid() and form.login_to_switzerland_mobility(request):
 
-            # cookies retrieved successfully
-            if cookies:
-                # add cookies to the user session
-                request.session["switzerland_mobility_cookies"] = cookies
+            # check for a redirection parameter in the url
+            import_id = request.POST.get("import", request.GET.get("import", ""))
+            update_id = request.POST.get("update", request.GET.get("update", ""))
 
-                # check if we can redirect to a route after login
-                route_id = request.POST.get("route_id", request.GET.get("route_id", ""))
-                if route_id:
-                    try:
-                        return redirect(
-                            "import_route",
-                            data_source="switzerland_mobility",
-                            source_id=route_id,
-                        )
+            # redirect to route import form
+            if import_id:
+                try:
+                    return redirect(
+                        "import_route",
+                        data_source="switzerland_mobility",
+                        source_id=import_id,
+                    )
+                except NoReverseMatch:
+                    # tempered querystring: ignore
+                    pass
 
-                    # someone messed up the query string
-                    except NoReverseMatch:
-                        pass
+            # redirect to route update form
+            if update_id:
+                try:
+                    return redirect("routes:update", pk=update_id)
+                except NoReverseMatch:
+                    # tempered querystring: ignore
+                    pass
 
-                return redirect("import_routes", data_source="switzerland_mobility")
+            # no parameter, redirect athlete to import_routes
+            return redirect("import_routes", data_source="switzerland_mobility")
 
-        # something went wrong, render the login page,
-        context = {"form": form}
-        return render(request, template, context)
-
-    # print the form
-    elif request.method == "GET":
-        context = {"form": SwitzerlandMobilityLogin()}
-        return render(request, template, context)
-
-    else:
-        return HttpResponse("Method not allowed", status=405)
+    template = "importers/switzerland_mobility/login.html"
+    context = {"form": form}
+    return render(request, template, context)

--- a/homebytwo/routes/models/route.py
+++ b/homebytwo/routes/models/route.py
@@ -304,7 +304,6 @@ class Route(RulesModelMixin, Track, metaclass=RulesModelBase):
 
         return route
 
-
     def find_possible_checkpoints(self, max_distance=75, updated_geom=False):
         """
         return places as checkpoints based on the route geometry.

--- a/homebytwo/routes/tests/test_gpx.py
+++ b/homebytwo/routes/tests/test_gpx.py
@@ -281,6 +281,7 @@ def gpx_route(athlete, settings):
 ###############
 
 
+@pytest.mark.skip
 def test_get_route_gpx_download_url(athlete, client, gpx_route):
     response = client.get(gpx_route.get_absolute_url())
     user = response.context["user"]
@@ -288,6 +289,7 @@ def test_get_route_gpx_download_url(athlete, client, gpx_route):
     assertContains(response, gpx_route.gpx_url)
 
 
+@pytest.mark.skip
 def test_get_route_garmin_upload_url(athlete, client, gpx_route):
     response = client.get(gpx_route.get_absolute_url())
     user = response.context["user"]
@@ -295,6 +297,7 @@ def test_get_route_garmin_upload_url(athlete, client, gpx_route):
     assertContains(response, gpx_route.garmin_upload_url)
 
 
+@pytest.mark.skip
 def test_get_route_garmin_activity_url(athlete, client, gpx_route):
     gpx_route.garmin_id = 123456
     gpx_route.save(update_fields=["garmin_id"])

--- a/homebytwo/routes/tests/test_gpx.py
+++ b/homebytwo/routes/tests/test_gpx.py
@@ -2,13 +2,14 @@ import json
 from os.path import dirname, realpath
 from xml.dom import minidom
 
-from django.conf import settings
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+import pytest
 import responses
 from garmin_uploader import api as garmin_api
 from mock import patch
+from pytest_django.asserts import assertContains, assertRedirects
 
 from ...utils.factories import AthleteFactory
 from ...utils.tests import create_route_with_checkpoints
@@ -174,7 +175,7 @@ class GPXTestCase(TestCase):
         gpx_url = reverse("routes:gpx", kwargs={"pk": self.route.pk})
         response = self.client.get(gpx_url)
 
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 403
 
     def test_download_route_gpx_route_with_no_schedule(self):
         assert "schedule" not in self.route.data.columns
@@ -183,36 +184,6 @@ class GPXTestCase(TestCase):
         file_content = b"".join(response.streaming_content).decode("utf-8")
 
         self.assertIn("<name>{}</name>".format(self.route.name), file_content)
-
-    @override_settings(GARMIN_ACTIVITY_URL="https://example.com/garmin/{}")
-    def test_garmin_activity_url(self):
-        self.route.garmin_id = 123456
-        self.route.save(update_fields=["garmin_id"])
-        garmin_url = settings.GARMIN_ACTIVITY_URL.format(self.route.garmin_id)
-
-        response = self.client.get(
-            reverse("routes:route", kwargs={"pk": self.route.id})
-        )
-        self.assertContains(response, garmin_url)
-
-    def test_garmin_upload_not_route_athlete(self):
-        second_athlete = AthleteFactory(user__password="123456")
-        self.client.login(username=second_athlete.user.username, password="123456")
-        response = self.client.get(
-            reverse("routes:garmin_upload", args=[self.route.pk])
-        )
-        self.assertEqual(response.status_code, 404)
-
-    def test_garmin_upload_view_success(self):
-        upload_url = reverse("routes:garmin_upload", args=[self.route.pk])
-        route_url = reverse("routes:route", args=[self.route.pk])
-
-        with patch(
-            "homebytwo.routes.tasks.upload_route_to_garmin_task.delay"
-        ) as mock_task:
-            response = self.client.get(upload_url)
-            self.assertRedirects(response, route_url)
-            self.assertTrue(mock_task.called)
 
     def test_garmin_upload_task_success(self):
         self.route.garmin_id = 123456
@@ -297,6 +268,39 @@ class GPXTestCase(TestCase):
         response = upload_route_to_garmin_task(self.route.pk, self.athlete.id)
 
         self.assertIn("Failed to delete activity", response)
+
+
+@pytest.fixture
+def gpx_route(athlete):
+    return create_route_with_checkpoints(number_of_checkpoints=5, athlete=athlete)
+
+
+def test_garmin_activity_url(athlete, client, gpx_route, settings):
+    settings.GARMIN_ACTIVITY_URL = "https://example.com/garmin/{}"
+    gpx_route.garmin_id = 123456
+    gpx_route.save(update_fields=["garmin_id"])
+    response = client.get(gpx_route.get_absolute_url())
+    user = response.context["user"]
+    assert user.has_perm(gpx_route.get_perm("garmin_upload"), gpx_route)
+    assertContains(response, gpx_route.garmin_activity_url)
+
+
+def test_garmin_upload_not_owner(athlete, client, gpx_route):
+    gpx_route.athlete = AthleteFactory()
+    gpx_route.save(update_fields=["athlete"])
+    response = client.get(gpx_route.get_absolute_url("garmin_upload"))
+
+    assert response.status_code == 403
+
+
+def test_garmin_upload(athlete, client, gpx_route):
+    upload_url = gpx_route.get_absolute_url("garmin_upload")
+    route_url = gpx_route.get_absolute_url()
+
+    with patch("homebytwo.routes.tasks.upload_route_to_garmin_task.delay") as mock_task:
+        response = client.get(upload_url)
+        assertRedirects(response, route_url)
+        assert mock_task.called
 
 
 def test_download_route_gpx_view(athlete, client):

--- a/homebytwo/routes/tests/test_route.py
+++ b/homebytwo/routes/tests/test_route.py
@@ -56,6 +56,10 @@ def test_display_url(athlete):
     assert match.app_name == "routes"
     assert match.url_name == "gpx"
 
+    match = resolve(route.garmin_upload_url)
+    assert match.app_name == "routes"
+    assert match.url_name == "garmin_upload"
+
     match = resolve(route.import_url)
     assert match.url_name == "import_route"
 

--- a/homebytwo/routes/tests/test_route.py
+++ b/homebytwo/routes/tests/test_route.py
@@ -577,8 +577,9 @@ def test_route_delete_404(athlete, client):
     assert response.status_code == 404
 
 
-def test_view_route(athlete, client):
-    route = RouteFactory(athlete=athlete)
+def test_view_route(athlete, client, settings):
+    settings.STRAVA_ROUTE_URL = "https://strava.route/%d"
+    route = RouteFactory(athlete=athlete, data_source="strava")
     url = route.get_absolute_url()
 
     button = '<a class="btn btn--secondary btn--block" href="{href}">{text}</a>'

--- a/homebytwo/routes/views.py
+++ b/homebytwo/routes/views.py
@@ -159,12 +159,20 @@ class RouteUpdate(RouteEdit):
         return get_object_or_404(Route, pk=pk)
 
     def get_object(self, queryset=None):
+        """
+        routes that do not have a data_source raise NotImplementedErrors
+        and trigger a 404.
+        """
         pk = self.kwargs.get(self.pk_url_kwarg)
         if pk is not None:
             route = get_object_or_404(Route, pk=pk)
-            return route.update_from_remote(
-                self.request.session.get("switzerland_mobility_cookies", None)
-            )
+
+            try:
+                return route.update_from_remote(
+                    self.request.session.get("switzerland_mobility_cookies", None)
+                )
+            except NotImplementedError:
+                raise Http404
 
     def get_form_kwargs(self):
         """Return the keyword arguments for instantiating the form."""

--- a/homebytwo/templates/routes/route/_route_edit_button.html
+++ b/homebytwo/templates/routes/route/_route_edit_button.html
@@ -1,9 +1,0 @@
-{% if user == route.athlete.user %}
-  <section id="edit_actions">
-    <div class="grid grid--multiline grid--center grid--small">
-      <div class="grid__item">
-        <a class="btn btn--secondary btn--block" href="{{ route.edit_url }}">Edit Route</a>
-      </div>
-    </div>
-  </section>
-{% endif %}

--- a/homebytwo/templates/routes/route/_route_edit_buttons.html
+++ b/homebytwo/templates/routes/route/_route_edit_buttons.html
@@ -1,10 +1,19 @@
+{% load rules %}
+
+{% has_perm "routes.change_route" user route as can_change_route %}
+{% has_perm "routes.update_route" user route as can_update_route %}
+
 <section id="edit_actions">
   <div class="grid grid--multiline grid--center grid--small">
-    <div class="grid__item">
-      <a class="btn btn--secondary btn--block" href="{{ route.update_url }}">Re-Import from Source</a>
-    </div>
-    <div class="grid__item">
-      <a class="btn btn--secondary btn--block" href="{{ route.edit_url }}">Add/Remove Checkpoints</a>
-    </div>
+    {% if can_change_route %}
+      <div class="grid__item">
+        <a class="btn btn--secondary btn--block" href="{{ route.edit_url }}">Add/Remove Checkpoints</a>
+      </div>
+    {% endif %}
+    {% if can_update_route %}
+      <div class="grid__item">
+        <a class="btn btn--secondary btn--block" href="{{ route.update_url }}">Re-Import from Source</a>
+      </div>
+    {% endif %}
   </div>
 </section>

--- a/homebytwo/templates/routes/route/_route_edit_buttons.html
+++ b/homebytwo/templates/routes/route/_route_edit_buttons.html
@@ -1,12 +1,10 @@
-{% if user == route.athlete.user %}
-  <section id="edit_actions">
-    <div class="grid grid--multiline grid--center grid--small">
-      <div class="grid__item sm-w-1/2">
-        <a class="btn btn--secondary btn--block" href="{{ route.update_url }}">Re-Import from Source</a>
-      </div>
-      <div class="grid__item sm-w-1/2">
-        <a class="btn btn--secondary btn--block" href="{{ route.edit_url }}">Add/Remove Checkpoints</a>
-      </div>
+<section id="edit_actions">
+  <div class="grid grid--multiline grid--center grid--small">
+    <div class="grid__item sm-w-1/2">
+      <a class="btn btn--secondary btn--block" href="{{ route.update_url }}">Re-Import from Source</a>
     </div>
-  </section>
-{% endif %}
+    <div class="grid__item sm-w-1/2">
+      <a class="btn btn--secondary btn--block" href="{{ route.edit_url }}">Add/Remove Checkpoints</a>
+    </div>
+  </div>
+</section>

--- a/homebytwo/templates/routes/route/_route_edit_buttons.html
+++ b/homebytwo/templates/routes/route/_route_edit_buttons.html
@@ -1,9 +1,9 @@
 <section id="edit_actions">
   <div class="grid grid--multiline grid--center grid--small">
-    <div class="grid__item sm-w-1/2">
+    <div class="grid__item">
       <a class="btn btn--secondary btn--block" href="{{ route.update_url }}">Re-Import from Source</a>
     </div>
-    <div class="grid__item sm-w-1/2">
+    <div class="grid__item">
       <a class="btn btn--secondary btn--block" href="{{ route.edit_url }}">Add/Remove Checkpoints</a>
     </div>
   </div>

--- a/homebytwo/templates/routes/route/_route_edit_buttons.html
+++ b/homebytwo/templates/routes/route/_route_edit_buttons.html
@@ -1,0 +1,12 @@
+{% if user == route.athlete.user %}
+  <section id="edit_actions">
+    <div class="grid grid--multiline grid--center grid--small">
+      <div class="grid__item sm-w-1/2">
+        <a class="btn btn--secondary btn--block" href="{{ route.update_url }}">Re-Import from Source</a>
+      </div>
+      <div class="grid__item sm-w-1/2">
+        <a class="btn btn--secondary btn--block" href="{{ route.edit_url }}">Add/Remove Checkpoints</a>
+      </div>
+    </div>
+  </section>
+{% endif %}

--- a/homebytwo/templates/routes/route/_route_garmin_upload.html
+++ b/homebytwo/templates/routes/route/_route_garmin_upload.html
@@ -1,4 +1,8 @@
-{% if user == route.athlete.user %}
+{% load rules %}
+
+{% has_perm "routes.garmin_upload_route" user route as can_upload_to_garmin %}
+
+{% if can_upload_to_garmin %}
   <section class="mrgv" id="garmin">
     <div class="grid grid--multiline grid--small">
       <div class="grid__item sm-w-2/3 lg-w-3/4">

--- a/homebytwo/templates/routes/route/_route_map.html
+++ b/homebytwo/templates/routes/route/_route_map.html
@@ -2,7 +2,7 @@
 
 {% if route.geom %}
   <section id="map">
-    <h2>Route Map</h2>
+    <h2 class="h3">Route Map</h2>
     {% leaflet_map "main" callback="route_map_init" %}
   </section>
 {% endif %}

--- a/homebytwo/templates/routes/route/_route_save_buttons.html
+++ b/homebytwo/templates/routes/route/_route_save_buttons.html
@@ -1,3 +1,7 @@
+{% load rules %}
+
+{% has_perm "routes.delete_route" user object as can_delete_route %}
+
 <div class="form-group grid grid--right">
   <div class="grid__item md-w-4/5 grid grid--tight">
     {# Edit or Update Route #}
@@ -9,9 +13,9 @@
       <input class="btn btn--primary btn--block mrgt-" type="submit" value="Import {{ object.name }}"/>
     {% endif %}
   </div>
-  <div class="grid__item md-w-4/5">
-    {% if object.pk %}
+  {% if object.pk and can_delete_route %}
+    <div class="grid__item md-w-4/5">
       <a href="{{ object.delete_url }}" class="btn btn--delete btn--block mrgt-">Delete {{ object.name }}</a>
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 </div>

--- a/homebytwo/templates/routes/route/_route_save_buttons.html
+++ b/homebytwo/templates/routes/route/_route_save_buttons.html
@@ -3,7 +3,7 @@
 {% has_perm "routes.delete_route" user object as can_delete_route %}
 
 <div class="form-group grid grid--right">
-  <div class="grid__item md-w-4/5 grid grid--tight">
+  <div class="grid__item lg-w-4/5 grid grid--tight">
     {# Edit or Update Route #}
     {% if object.pk %}
       <a href="{{ object.display_url }}" class="btn btn--default btn--block mrgt-">Cancel</a>
@@ -14,7 +14,7 @@
     {% endif %}
   </div>
   {% if object.pk and can_delete_route %}
-    <div class="grid__item md-w-4/5">
+    <div class="grid__item lg-w-4/5">
       <a href="{{ object.delete_url }}" class="btn btn--delete btn--block mrgt-">Delete {{ object.name }}</a>
     </div>
   {% endif %}

--- a/homebytwo/templates/routes/route/_route_schedule.html
+++ b/homebytwo/templates/routes/route/_route_schedule.html
@@ -1,3 +1,7 @@
+{% load rules %}
+
+{% has_perm "routes.change_route" user route as can_change_route %}
+
 <section id="schedule">
   <h2 class="h3">Route Schedule</h2>
   {% include "routes/route/_performance_box.html" %}
@@ -13,5 +17,7 @@
     {# finish place #}
     {% include "routes/route/_route_checkpoint.html" with type="Finish" place=route.end_place altitude=route.get_end_altitude.m schedule=route.get_total_duration distance=route.get_total_distance.km elevation_gain=route.get_total_elevation_gain.m elevation_loss=route.get_total_elevation_loss.m %}
   </ul>
-  {% include "routes/route/_route_edit_buttons.html" %}
+  {% if can_change_route %}
+    {% include "routes/route/_route_edit_buttons.html" %}
+  {% endif %}
 </section>

--- a/homebytwo/templates/routes/route/_route_schedule.html
+++ b/homebytwo/templates/routes/route/_route_schedule.html
@@ -13,5 +13,5 @@
     {# finish place #}
     {% include "routes/route/_route_checkpoint.html" with type="Finish" place=route.end_place altitude=route.get_end_altitude.m schedule=route.get_total_duration distance=route.get_total_distance.km elevation_gain=route.get_total_elevation_gain.m elevation_loss=route.get_total_elevation_loss.m %}
   </ul>
-  {% include "routes/route/_route_edit_button.html" %}
+  {% include "routes/route/_route_edit_buttons.html" %}
 </section>

--- a/homebytwo/templates/routes/route/_route_schedule.html
+++ b/homebytwo/templates/routes/route/_route_schedule.html
@@ -1,7 +1,3 @@
-{% load rules %}
-
-{% has_perm "routes.change_route" user route as can_change_route %}
-
 <section id="schedule">
   <h2 class="h3">Route Schedule</h2>
   {% include "routes/route/_performance_box.html" %}
@@ -17,7 +13,5 @@
     {# finish place #}
     {% include "routes/route/_route_checkpoint.html" with type="Finish" place=route.end_place altitude=route.get_end_altitude.m schedule=route.get_total_duration distance=route.get_total_distance.km elevation_gain=route.get_total_elevation_gain.m elevation_loss=route.get_total_elevation_loss.m %}
   </ul>
-  {% if can_change_route %}
-    {% include "routes/route/_route_edit_buttons.html" %}
-  {% endif %}
+  {% include "routes/route/_route_edit_buttons.html" %}
 </section>

--- a/homebytwo/templates/routes/route/route.html
+++ b/homebytwo/templates/routes/route/route.html
@@ -17,7 +17,6 @@
   {% include "routes/route/_route_schedule.html" %}
   {% include "routes/route/_route_map.html" %}
   {% include "routes/route/_route_source_link.html" %}
-  {% include "routes/route/_route_garmin_upload.html" %}
 {% endblock content %}
 
 {% if route.geom %}

--- a/homebytwo/templates/routes/route/route.html
+++ b/homebytwo/templates/routes/route/route.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% load leaflet_tags geojson_tags humanize %}
+{% load geojson_tags humanize leaflet_tags %}
+
 
 {% block title %}Home by Two - {{ route.name }}{% endblock %}
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,6 +19,7 @@ polyline
 psycopg2-binary
 rcssmin
 requests
+rules
 scikit-learn
 sentry-sdk
 social-auth-core

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,6 +55,7 @@ pytz==2020.4              # via celery, django, flower, pandas, stravalib
 rcssmin==1.0.6            # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via -r requirements/base.in, codaio, garmin-uploader, requests-oauthlib, social-auth-core, stravalib
+rules==2.2                # via -r requirements/base.in
 scikit-learn==0.23.2      # via -r requirements/base.in
 scipy==1.5.3              # via scikit-learn
 sentry-sdk==0.19.1        # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -80,6 +80,7 @@ pytz==2020.4              # via celery, django, flower, pandas, stravalib
 rcssmin==1.0.6            # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via -r requirements/base.in, codaio, garmin-uploader, requests-oauthlib, social-auth-core, stravalib
+rules==2.2                # via -r requirements/base.in
 scikit-learn==0.23.2      # via -r requirements/base.in
 scipy==1.5.3              # via scikit-learn
 sentry-sdk==0.19.1        # via -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -81,6 +81,7 @@ rcssmin==1.0.6            # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via -r requirements/base.in, codaio, coveralls, garmin-uploader, requests-oauthlib, responses, social-auth-core, stravalib
 responses==0.12.0         # via -r requirements/test.in
+rules==2.2                # via -r requirements/base.in
 scikit-learn==0.23.2      # via -r requirements/base.in
 scipy==1.5.3              # via scikit-learn
 sentry-sdk==0.19.1        # via -r requirements/base.in


### PR DESCRIPTION
Improve the user experience a little by adding an update button on the route page and prevent athletes from updating or deleting other athletes' routes. fixes #87 and #26:
- [x] Implement rules to manage route permissions at the object level
- [x] Redirect to update page after Switzerland Mobility login 